### PR TITLE
cabal: expand bounds of vty to match reflex-vty

### DIFF
--- a/reflex-ghci.cabal
+++ b/reflex-ghci.cabal
@@ -42,7 +42,7 @@ library
     , text >= 1.2 && < 2.1
     , these > 1 && < 2
     , unix >= 2.7 && < 2.9
-    , vty >=5.21 && <5.39
+    , vty >= 5.21 && < 6.2
   hs-source-dirs: src
   default-language: Haskell2010
   ghc-options: -Wall

--- a/release.nix
+++ b/release.nix
@@ -9,15 +9,25 @@ let
   commonOverrides = self: super: {
     vty = self.callHackageDirect {
       pkg = "vty";
-      ver = "5.38";
-      sha256 = "0kcd3ln9xmc62ka0i7habzvjjar8z63mlvl15rdhf8hqmda0b7r7";
+      ver = "6.1";
+      sha256 = "2cefcb5764f6b662440ba9e56c30282da37071b599a7def7fc8e5679f2602bf8";
+    } {};
+    vty-crossplatform = self.callHackageDirect {
+      pkg = "vty-crossplatform";
+      ver = "0.4.0.0";
+      sha256 = "sha256-e3LnG3ouGpR/glpEof3qLj4UeURBDEKGOQqkEkpWNYs=";
+    } {};
+    vty-unix = self.callHackageDirect {
+      pkg = "vty-unix";
+      ver = "0.2.0.0";
+      sha256 = "sha256-sDoxXxqo9w5eOqs2uI7S5JzWRsVrHjTBldrhPJKcqSY=";
     } {};
     reflex = self.callCabal2nix "reflex" (rp.hackGet ./dep/reflex) {};
     reflex-process = self.callCabal2nix "reflex-process" (rp.hackGet ./dep/reflex-process) {};
-		reflex-vty = self.callHackageDirect {
+    reflex-vty = self.callHackageDirect {
       pkg = "reflex-vty";
-			ver = "0.5.1.0";
-			sha256 = "0h6fh2aiy5m9l5v1fnrdi3pwx15p37vqv1yhp6556yzcb3bnbmyp";
+      ver = "0.5.2.0";
+      sha256 = "sha256-AsqIRmJiMYsnx2jBLaSvQUNOz92YiDlVu6KfR1PBCZk=";
     } {};
     reflex-fsnotify = self.callHackageDirect {
       pkg = "reflex-fsnotify";
@@ -51,12 +61,6 @@ let
           ver = "0.0.8.2";
           sha256 = "160zqqhjg48fr3a33gffd82qm3728c8hwf8sn37pbpv82fw71rzg";
         } {};
-
-        reflex = self.callHackageDirect {
-          pkg = "reflex";
-          ver = "0.9.0.1";
-          sha256 = "1yrcashxxclvlvv3cs5gv75rvlsg1gb0m36kssnk2zvhbh94240y";
-        } {};
       };
     };
     nixGhc961 = (import ./nixpkgs { inherit system; }).haskell.packages.ghc961.override {
@@ -67,11 +71,6 @@ let
           sha256 = "160zqqhjg48fr3a33gffd82qm3728c8hwf8sn37pbpv82fw71rzg";
         } {};
 
-        reflex = self.callHackageDirect {
-          pkg = "reflex";
-          ver = "0.9.0.1";
-          sha256 = "1yrcashxxclvlvv3cs5gv75rvlsg1gb0m36kssnk2zvhbh94240y";
-        } {};
         these-lens = self.callHackageDirect {
           pkg = "these-lens";
           ver = "1.0.1.3";
@@ -97,11 +96,6 @@ let
           pkg = "strict";
           ver = "0.5";
           sha256 = "02iyvrr7nd7fnivz78lzdchy8zw1cghqj1qx2yzbbb9869h1mny7";
-        } {};
-        vty = self.callHackageDirect {
-          pkg = "vty";
-          ver = "5.38";
-          sha256 = "0kcd3ln9xmc62ka0i7habzvjjar8z63mlvl15rdhf8hqmda0b7r7";
         } {};
         # Jailbroken until https://github.com/audreyt/string-qq/pull/3
         string-qq = haskellLib.dontCheck super.string-qq;


### PR DESCRIPTION
This allows building reflex-ghci with reflex-vty-0.5.2.0.
